### PR TITLE
Get model name for CompoundUniqueInput

### DIFF
--- a/@generated/user/user-email-name-compound-unique.input.ts
+++ b/@generated/user/user-email-name-compound-unique.input.ts
@@ -1,0 +1,15 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import * as Scalars from 'graphql-scalars';
+import * as Validator from 'class-validator';
+
+@InputType()
+export class UserEmailNameCompoundUniqueInput {
+    @Field(() => Scalars.GraphQLEmailAddress, { nullable: false })
+    email!: string;
+
+    @Field(() => String, { nullable: false })
+    @Validator.MinLength(3)
+    @Validator.MaxLength(50)
+    name!: string;
+}

--- a/@generated/user/user-where-unique.input.ts
+++ b/@generated/user/user-where-unique.input.ts
@@ -2,6 +2,7 @@ import { Field } from '@nestjs/graphql';
 import { InputType } from '@nestjs/graphql';
 import * as Scalars from 'graphql-scalars';
 import * as Validator from 'class-validator';
+import { UserEmailNameCompoundUniqueInput } from './user-email-name-compound-unique.input';
 
 @InputType()
 export class UserWhereUniqueInput {
@@ -15,4 +16,7 @@ export class UserWhereUniqueInput {
     @Validator.MinLength(3)
     @Validator.MaxLength(50)
     name?: string;
+
+    @Field(() => UserEmailNameCompoundUniqueInput, { nullable: true })
+    email_name?: UserEmailNameCompoundUniqueInput;
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,8 @@ model User {
   rating           Float?
   role             Role?
   profile          Profile?
+
+  @@unique([email, name])
 }
 
 model Tag {

--- a/src/helpers/get-model-name.ts
+++ b/src/helpers/get-model-name.ts
@@ -39,9 +39,10 @@ function getModelName(args: {
     // test for {Model}{UniqueName}CompoundUniqueInput
     if (name.slice(-19) === 'CompoundUniqueInput') {
         const test = name.slice(0, -19);
-        const model = modelNames.find(x => test.startsWith(x));
-        if (model) {
-            return model;
+        const model = modelNames.filter(x => test.startsWith(x));
+        const bestMatch = model.sort((a,b) => b.length - a.length)?.[0]
+        if (bestMatch) {
+            return bestMatch;
         }
     } 
 

--- a/src/helpers/get-model-name.ts
+++ b/src/helpers/get-model-name.ts
@@ -35,6 +35,16 @@ function getModelName(args: {
             return test;
         }
     }
+
+    // test for {Model}{UniqueName}CompoundUniqueInput
+    if (name.slice(-19) === 'CompoundUniqueInput') {
+        const test = name.slice(0, -19);
+        const model = modelNames.find(x => test.startsWith(x));
+        if (model) {
+            return model;
+        }
+    } 
+
     // test for {Model}Count
     if (name.slice(-5) === 'Count') {
         const test = name.slice(0, -5);

--- a/src/test/generate.spec.ts
+++ b/src/test/generate.spec.ts
@@ -1559,6 +1559,8 @@ describe('emit single and decorators', () => {
                   name String
                   /// @PropertyType({ name: 'G.Email', from: 'graphql-type-email' })
                   email String?
+
+                  @@unique([email, name])
                 }
                 `,
             options: [
@@ -1601,6 +1603,19 @@ describe('emit single and decorators', () => {
             expect(trim(d?.getFullText())).toEqual('@Validator.MinLength(3)');
         });
     });
+
+    describe('user unique input compound', () => {
+        let property: PropertyDeclaration;
+        before(() => {
+            property = sourceFile.getClass('UserEmailNameCompoundUniqueInput')?.getProperty('name')!;
+        });
+
+        it('decorator validator', () => {
+            const d = property.getDecorator(d => d.getFullText().includes('MinLength'));
+            expect(trim(d?.getFullText())).toEqual('@Validator.MinLength(3)');
+        });
+    });
+
 
     // it('^', () => console.log(sourceFile.getText()));
 });

--- a/src/test/generate.spec.ts
+++ b/src/test/generate.spec.ts
@@ -1607,7 +1607,9 @@ describe('emit single and decorators', () => {
     describe('user unique input compound', () => {
         let property: PropertyDeclaration;
         before(() => {
-            property = sourceFile.getClass('UserEmailNameCompoundUniqueInput')?.getProperty('name')!;
+            property = sourceFile
+                .getClass('UserEmailNameCompoundUniqueInput')
+                ?.getProperty('name')!;
         });
 
         it('decorator validator', () => {


### PR DESCRIPTION
Prisma `@@unique([field1, field2], name: "constraint_name")`  generates a {Model}{ConstraintName}CompoundUniqueInput.

The function getModelName was returning undefined and because of that the @FieldType was not applying.

I could not get endsWithKeywords to work in this case since the ConstraintName won't allow the test to match the model name. Maybe there's a safer way to find the right model, I did a startsWith and checked for the longest match but still looks to lax.

```typescript
  if (name.slice(-19) === 'CompoundUniqueInput') {
          const test = name.slice(0, -19);
          const model = modelNames.filter(x => test.startsWith(x));
          const bestMatch = model.sort((a,b) => b.length - a.length)?.[0]
          if (bestMatch) {
              return bestMatch;
          }
      } 
```