### PR TITLE
feat(match): Allows `match` expressions in `FieldType` and `PropertyType`

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,10 @@ export class UserCreateInput {
 
 #### @FieldType()
 
-Allow set custom type for field
+Allow set custom GraphQL scalar type for field
+
+To override scalar type in specific classes, you can use glob pattern `match: string | string[]`
+see [outmatch](https://github.com/axtgr/outmatch#usage) for details.
 
 ```prisma
 model User {
@@ -478,6 +481,9 @@ Missing field options will merged from generator configuration.
 #### @PropertyType()
 
 Similar to `@FieldType()` but refer to TypeScript property (actually field too).
+
+To override TypeScript type in specific classes, you can use glob pattern `match: string | string[]`
+see [outmatch](https://github.com/axtgr/outmatch#usage) for details.
 
 Named import example:
 

--- a/src/handlers/input-type.ts
+++ b/src/handlers/input-type.ts
@@ -103,7 +103,7 @@ export function inputType(
         });
         classStructure.properties?.push(property);
 
-        if (propertySettings && propertySettings.input) {
+        if (propertySettings) {
             importDeclarations.create({ ...propertySettings });
         }
 

--- a/src/handlers/input-type.ts
+++ b/src/handlers/input-type.ts
@@ -82,7 +82,10 @@ export function inputType(
         const { isList, location, type } = graphqlInputType;
         const typeName = String(type);
         const settings = modelFieldSettings?.get(name);
-        const propertySettings = settings?.getPropertyType();
+        const propertySettings = settings?.getPropertyType({
+            name: inputType.name,
+            input: true,
+        });
         const isCustomsApplicable =
             typeName === model?.fields.find(f => f.name === name)?.type;
         const propertyType = castArray(
@@ -98,10 +101,9 @@ export function inputType(
             propertyType,
             isList,
         });
-
         classStructure.properties?.push(property);
 
-        if (propertySettings) {
+        if (propertySettings && propertySettings.input) {
             importDeclarations.create({ ...propertySettings });
         }
 
@@ -112,9 +114,12 @@ export function inputType(
             ok(property.decorators);
 
             let graphqlType: string;
-            const fieldType = settings?.getFieldType();
+            const fieldType = settings?.getFieldType({
+                name: inputType.name,
+                input: true,
+            });
 
-            if (fieldType && fieldType.input && isCustomsApplicable) {
+            if (fieldType && isCustomsApplicable) {
                 graphqlType = fieldType.name;
                 importDeclarations.create({ ...fieldType });
             } else {

--- a/src/handlers/model-output-type.ts
+++ b/src/handlers/model-output-type.ts
@@ -82,8 +82,14 @@ export function modelOutputType(outputType: OutputType, args: EventArguments) {
         }
         const modelField = modelFields.get(model.name)?.get(field.name);
         const settings = fieldSettings.get(model.name)?.get(field.name);
-        const fieldType = settings?.getFieldType();
-        const propertySettings = settings?.getPropertyType();
+        const fieldType = settings?.getFieldType({
+            name: outputType.name,
+            output: true,
+        });
+        const propertySettings = settings?.getPropertyType({
+            name: outputType.name,
+            output: true,
+        });
 
         const propertyType = castArray(
             propertySettings?.name ||
@@ -102,7 +108,7 @@ export function modelOutputType(outputType: OutputType, args: EventArguments) {
 
         let graphqlType: string;
 
-        if (fieldType && fieldType.output) {
+        if (fieldType) {
             graphqlType = fieldType.name;
             importDeclarations.create({ ...fieldType });
         } else {

--- a/src/handlers/output-type.ts
+++ b/src/handlers/output-type.ts
@@ -59,7 +59,10 @@ export function outputType(outputType: OutputType, args: EventArguments) {
         const settings = isCountOutput
             ? undefined
             : model && fieldSettings.get(model.name)?.get(field.name);
-        const propertySettings = settings?.getPropertyType();
+        const propertySettings = settings?.getPropertyType({
+            name: outputType.name,
+            output: true,
+        });
         const isCustomsApplicable =
             outputTypeName === model?.fields.find(f => f.name === field.name)?.type;
 
@@ -93,9 +96,12 @@ export function outputType(outputType: OutputType, args: EventArguments) {
             property.decorators.push({ name: 'HideField', arguments: [] });
         } else {
             let graphqlType: string;
-            const fieldType = settings?.getFieldType();
+            const fieldType = settings?.getFieldType({
+                name: outputType.name,
+                output: true,
+            });
 
-            if (fieldType && fieldType.output && isCustomsApplicable) {
+            if (fieldType && isCustomsApplicable) {
                 graphqlType = fieldType.name;
                 importDeclarations.create({ ...fieldType });
             } else {

--- a/src/helpers/object-settings.ts
+++ b/src/helpers/object-settings.ts
@@ -22,16 +22,18 @@ export type ObjectSetting = {
     namedImport?: boolean;
 };
 
+interface ObjectSettingsFilterArgs {
+    name: string;
+    input?: boolean;
+    output?: boolean;
+}
+
 export class ObjectSettings extends Array<ObjectSetting> {
     shouldHideField({
         name,
         input = false,
         output = false,
-    }: {
-        name: string;
-        input?: boolean;
-        output?: boolean;
-    }): boolean {
+    }: ObjectSettingsFilterArgs): boolean {
         const hideField = this.find(s => s.name === 'HideField');
 
         return Boolean(
@@ -41,54 +43,51 @@ export class ObjectSettings extends Array<ObjectSetting> {
         );
     }
 
-    getFieldType(args?: {
-        name: string;
-        input?: boolean;
-        output?: boolean;
-    }): ObjectSetting | undefined {
-          if (!args) return this.find(s => s.kind === 'FieldType');
+    /* eslint-disable consistent-return */
+    getFieldType({
+        name,
+        input,
+        output,
+    }: ObjectSettingsFilterArgs): ObjectSetting | undefined {
+        const fieldType = this.find(s => s.kind === 'FieldType');
 
-          const fieldType = this.find(s => s.kind === 'FieldType');
+        if (!fieldType) {
+            return undefined;
+        }
 
-          if (fieldType?.input && args.input) {
-                  return fieldType;
-          }
+        if (fieldType.match) {
+            // eslint-disable-next-line unicorn/prefer-regexp-test
+            return fieldType.match(name) ? fieldType : undefined;
+        }
 
-          if (fieldType?.output && args.output) {
-                  return fieldType;
-          }
+        if (input && !fieldType.input) {
+            return undefined;
+        }
 
-          if (fieldType?.match?.(args.name)) {
-                  return fieldType;
-          }
+        if (output && !fieldType.output) {
+            return undefined;
+        }
 
-          // eslint-disable-next-line consistent-return
-          return undefined;
+        return fieldType;
     }
+    /* eslint-enable consistent-return */
 
-    getPropertyType(args?: {
-        name: string;
-        input?: boolean;
-        output?: boolean;
-    }): ObjectSetting | undefined  {
-        if (!args) return this.find(s => s.kind === 'PropertyType');
-
+    /* eslint-disable consistent-return */
+    getPropertyType({ name }: ObjectSettingsFilterArgs): ObjectSetting | undefined {
         const propertyType = this.find(s => s.kind === 'PropertyType');
 
-        if (propertyType?.input && args.input) {
-                return propertyType;
+        if (!propertyType) {
+            return undefined;
         }
 
-        if (propertyType?.output && args.output) {
-                return propertyType;
+        // eslint-disable-next-line unicorn/prefer-regexp-test
+        if (propertyType.match && !propertyType.match(name)) {
+            return undefined;
         }
 
-        if (propertyType?.match?.(args.name)) {
-                return propertyType;
-        }
-
-        // eslint-disable-next-line consistent-return
-        return undefined;    }
+        return propertyType;
+    }
+    /* eslint-enable consistent-return */
 
     getObjectTypeArguments(options: Record<string, any>): string[] {
         const objectTypeOptions = merge({}, options);

--- a/src/helpers/object-settings.ts
+++ b/src/helpers/object-settings.ts
@@ -41,13 +41,54 @@ export class ObjectSettings extends Array<ObjectSetting> {
         );
     }
 
-    getFieldType() {
-        return this.find(s => s.kind === 'FieldType');
+    getFieldType(args?: {
+        name: string;
+        input?: boolean;
+        output?: boolean;
+    }): ObjectSetting | undefined {
+          if (!args) return this.find(s => s.kind === 'FieldType');
+
+          const fieldType = this.find(s => s.kind === 'FieldType');
+
+          if (fieldType?.input && args.input) {
+                  return fieldType;
+          }
+
+          if (fieldType?.output && args.output) {
+                  return fieldType;
+          }
+
+          if (fieldType?.match?.(args.name)) {
+                  return fieldType;
+          }
+
+          // eslint-disable-next-line consistent-return
+          return undefined;
     }
 
-    getPropertyType() {
-        return this.find(s => s.kind === 'PropertyType');
-    }
+    getPropertyType(args?: {
+        name: string;
+        input?: boolean;
+        output?: boolean;
+    }): ObjectSetting | undefined  {
+        if (!args) return this.find(s => s.kind === 'PropertyType');
+
+        const propertyType = this.find(s => s.kind === 'PropertyType');
+
+        if (propertyType?.input && args.input) {
+                return propertyType;
+        }
+
+        if (propertyType?.output && args.output) {
+                return propertyType;
+        }
+
+        if (propertyType?.match?.(args.name)) {
+                return propertyType;
+        }
+
+        // eslint-disable-next-line consistent-return
+        return undefined;    }
 
     getObjectTypeArguments(options: Record<string, any>): string[] {
         const objectTypeOptions = merge({}, options);
@@ -146,6 +187,11 @@ function customType(args: string) {
     if ((options as { name: string | undefined }).name?.includes('.')) {
         result.namespaceImport = namespace;
     }
+
+    if (typeof options.match === 'string' || Array.isArray(options.match)) {
+        result.match = outmatch(options.match, { separator: false });
+    }
+
     return result;
 }
 

--- a/src/test/generate.spec.ts
+++ b/src/test/generate.spec.ts
@@ -14,7 +14,7 @@ import {
 } from 'ts-morph';
 
 import { EventArguments } from '../types';
-import { getFieldOptions, getHumanReadableType, getPropertyStructure } from './helpers';
+import { getFieldOptions, getPropertyStructure } from './helpers';
 import { testGenerate } from './test-generate';
 
 let sourceFile: SourceFile;
@@ -122,7 +122,7 @@ describe('model with one id int', () => {
 
         it('object type description', () => {
             const decoratorArgument = classFile.getDecorators()[0].getStructure()
-                ?.arguments?.[0] as string | undefined;
+                .arguments?.[0] as string | undefined;
             expect(decoratorArgument).toMatch(/description:\s*["']User really["']/);
         });
 
@@ -2156,27 +2156,28 @@ describe('property type', () => {
 
         it('should use default scalar type in model', () => {
             setSourceFile('user.model.ts');
-            expect(getHumanReadableType(sourceFile, 'profile')).toEqual('any');
+            expect(p('profile')?.type).toEqual('any');
         });
 
         it('should use default scalar type in user-create-many.input', () => {
             setSourceFile('user-create-many.input.ts');
-            expect(getHumanReadableType(sourceFile, 'profile')).toEqual('any');
+            expect(p('profile')?.type).toEqual('any');
         });
 
         it('user-create.input', () => {
             setSourceFile('user-create.input.ts');
-            expect(getHumanReadableType(sourceFile, 'profile')).toEqual('JsonObject');
+            expect(p('profile')?.type).toEqual('JsonObject');
+
         });
 
         it('should use default scalar type in user-update-many-mutation.input', () => {
             setSourceFile('user-update-many-mutation.input.ts');
-            expect(getHumanReadableType(sourceFile, 'profile')).toEqual('any');
+            expect(p('profile')?.type).toEqual('any');
         });
 
         it('user-update.input', () => {
             setSourceFile('user-update.input.ts');
-            expect(getHumanReadableType(sourceFile, 'profile')).toEqual('JsonObject');
+            expect(p('profile')?.type).toEqual('JsonObject');
         });
     });
 });

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -19,11 +19,3 @@ export function getPropertyStructure(sourceFile: SourceFile, name: string) {
         ?.getProperty(p => p.getName() === name)
         ?.getStructure();
 }
-
-export function getHumanReadableType(sourceFile: SourceFile, name: string) {
-    return sourceFile
-        .getClass(() => true)
-        ?.getProperty(p => p.getName() === name)
-        ?.getTypeNode()
-        ?.getText();
-}

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -19,3 +19,11 @@ export function getPropertyStructure(sourceFile: SourceFile, name: string) {
         ?.getProperty(p => p.getName() === name)
         ?.getStructure();
 }
+
+export function getHumanReadableType(sourceFile: SourceFile, name: string) {
+    return sourceFile
+        .getClass(() => true)
+        ?.getProperty(p => p.getName() === name)
+        ?.getTypeNode()
+        ?.getText();
+}


### PR DESCRIPTION
Previously, you could only specify `input` and `output` for these two `Prisma.schema` decorators.
Now it's possible to apply `match` patterns. ~~Hirarchy of arguments is the same as for `HideField`~~

The `match` option takes precedence over `input` and `output`.
Behaviour of `input` and `output` have not changed