### PR TITLE
Fixes PropertyType behavior when defining on generator level

### DIFF
--- a/src/helpers/object-settings.ts
+++ b/src/helpers/object-settings.ts
@@ -71,15 +71,27 @@ export class ObjectSettings extends Array<ObjectSetting> {
         return fieldType;
     }
 
-    getPropertyType({ name }: ObjectSettingsFilterArgs): ObjectSetting | undefined {
+    getPropertyType({
+        name,
+        input,
+        output,
+    }: ObjectSettingsFilterArgs): ObjectSetting | undefined {
         const propertyType = this.find(s => s.kind === 'PropertyType');
 
         if (!propertyType) {
             return undefined;
         }
 
-        // eslint-disable-next-line unicorn/prefer-regexp-test
-        if (propertyType.match && !propertyType.match(name)) {
+        if (propertyType.match) {
+            // eslint-disable-next-line unicorn/prefer-regexp-test
+            return propertyType.match(name) ? propertyType : undefined;
+        }
+
+        if (input && !propertyType.input) {
+            return undefined;
+        }
+
+        if (output && !propertyType.output) {
             return undefined;
         }
 

--- a/src/test/generate.spec.ts
+++ b/src/test/generate.spec.ts
@@ -1431,7 +1431,7 @@ describe('emit single and decorators', () => {
                   id    Int    @id
                   /// @Validator.MinLength(3)
                   name String
-                  /// @PropertyType({ name: 'G.Email', from: 'graphql-type-email' })
+                  /// @PropertyType({ name: 'G.Email', from: 'graphql-type-email', input: true })
                   email String?
                 }
                 `,
@@ -2023,6 +2023,70 @@ describe('property type', () => {
         it('user-update.input', () => {
             setSourceFile('user-update.input.ts');
             expect(p('profile')?.type).toEqual('JsonObject');
+        });
+    });
+
+    describe('it respects input from generator level field configuration', () => {
+        before(async () => {
+            ({ project, sourceFiles } = await testGenerate({
+                schema: `
+              model User {
+                id Int @id
+                /// @PropertyType('JsonObject')
+                profile Json
+              }
+              `,
+                options: [
+                    `
+                  fields_JsonObject_from         = "type-fest"
+                  fields_JsonObject_namedImport  = true
+                  fields_JsonObject_input        = true
+                  fields_JsonObject_output       = false
+                `,
+                ],
+            }));
+        });
+
+        it('should use default scalar type in model', () => {
+            setSourceFile('user.model.ts');
+            expect(p('profile')?.type).toEqual('any');
+        });
+
+        it('user-create.input', () => {
+            setSourceFile('user-create.input.ts');
+            expect(p('profile')?.type).toEqual('JsonObject');
+        });
+    });
+
+    describe('it respects output from generator level field configuration', () => {
+        before(async () => {
+            ({ project, sourceFiles } = await testGenerate({
+                schema: `
+              model User {
+                id Int @id
+                /// @PropertyType('JsonObject')
+                profile Json
+              }
+              `,
+                options: [
+                    `
+                  fields_JsonObject_from         = "type-fest"
+                  fields_JsonObject_namedImport  = true
+                  fields_JsonObject_input        = false
+                  fields_JsonObject_output       = true
+                `,
+                ],
+            }));
+        });
+
+        it('should use default scalar type in model', () => {
+            setSourceFile('user.model.ts');
+            expect(p('profile')?.type).toEqual('JsonObject');
+        });
+
+        it('user-create.input', () => {
+            setSourceFile('user-create.input.ts');
+            expect(p('profile')?.type).toEqual('any');
         });
     });
 });


### PR DESCRIPTION
When defining a field namespace on generator level, using the same namespace in FieldType and PropertyType result in different outcomes.
This was due to `ObjectSettings.getPropertyType` not respecting `input` and `output` props.