### PR TITLE
Fix generator provider in README for yarn monorepos

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install --save-dev prisma-nestjs-graphql
 
 ```prisma
 generator nestgraphql {
-    provider = "node node_modules/prisma-nestjs-graphql"
+    provider = "prisma-nestjs-graphql"
     output = "../src/@generated/prisma-nestjs-graphql"
 }
 ```


### PR DESCRIPTION
In yarn workspace monorepos node_modules is located in the root folder (if at all), not `node_modules/prisma-nestjs-graphql`.
Prisma will find the proper package if the package name is given directly i.e. `provider = "prisma-nestjs-graphql"`