### PR TITLE
Support reexport with custom output pattern

### DIFF
--- a/src/test/generate.spec.ts
+++ b/src/test/generate.spec.ts
@@ -1548,6 +1548,37 @@ describe('reexport option', () => {
         });
     });
 
+    describe('reexport directories with output file pattern', () => {
+        before(async () => {
+            ({ project, sourceFiles } = await testGenerate({
+                schema: `
+                model User {
+                    id Int @id
+                }`,
+                options: [
+                    'reExport = Directories',
+                    `outputFilePattern = "{model}/{plural.type}/{name}.{type}.ts"`,
+                ],
+            }));
+        });
+
+        it('user should export plural types', () => {
+            sourceFile = project.getSourceFile(s =>
+                s.getFilePath().endsWith('/user/index.ts'),
+            )!;
+
+            for (const exp of [
+                `export * from './args';`,
+                `export * from './enums';`,
+                `export * from './inputs';`,
+                `export * from './models';`,
+                `export * from './outputs';`,
+            ]) {
+                expect(sourceFile.getText()).toContain(exp);
+            }
+        });
+    });
+
     describe('reexport single', () => {
         before(async () => {
             ({ project, sourceFiles } = await testGenerate({


### PR DESCRIPTION
Currently, this configuration doesn't work, it creates empty index.ts files on paths like `user/index.ts`.

```
outputFilePattern = "{model}/{plural.type}/{name}.{type}.ts"
reExport = Directories
```

This pr tries to add support to complex file patterns in combination with the reExport option