### PR TITLE
feat: Allow the use of the generate function without the onGenerate p…

### DIFF
--- a/Taskfile
+++ b/Taskfile
@@ -59,7 +59,7 @@ compatibilty_check() {
 
 bundle() {
   set -x
-  npx tsup src/index.ts --format cjs --target es2020
+  npx tsup --entry src/index.ts --entry src/generate.ts --format cjs --target es2020
   cp -fv README.md LICENSE package.json dist
   cp -fv src/bin.js dist
 }
@@ -75,7 +75,7 @@ commit_lint() {
 commit_check() {
   set -x
   from=$(git_last_release_tag)
-  commitlint --from $from
+  commitlint --from "$from"
 }
 
 "$@"

--- a/Taskfile
+++ b/Taskfile
@@ -75,7 +75,7 @@ commit_lint() {
 commit_check() {
   set -x
   from=$(git_last_release_tag)
-  commitlint --from "$from"
+  commitlint --from $from
 }
 
 "$@"

--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
   "bin": "bin.js",
   "exports": {
     ".": "./index.js",
-    "./generate": {
-      "require": "./generate.js"
-    }
+    "./generate": "./generate.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "description": "Generate object types, inputs, args, etc. from prisma schema file for usage with @nestjs/graphql module",
   "main": "index.js",
   "bin": "bin.js",
+  "exports": {
+    ".": "./index.js",
+    "./generate": {
+      "require": "./generate.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/unlight/nestjs-graphql-prisma.git"


### PR DESCRIPTION
## Goal of this PR

This PR is intend to allow developer to use the generate function from this repository without the `onGenerate` function callback. This will allow developers to use this package and to share generator with preconfigured options.

This PR does not include the types (that can be good to generate de types with the package).

This PR doesn't contain breaking changes
