### PR TITLE
feature: Add options to generate only selected blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,18 @@ with temporal dead zone when generating merged file.
 Type: `boolean`  
 Default: `false`
 
-#### `purgeOutput`
+#### `emitBlocks`
+Emit only selected blocks. Be aware, that some blocks do depend on others, e.g. one can't emit `models` without emitting `enums`.  
+Type: `("args" | "inputs" | "outputs" | "models" | "enums")[]`  
+Default: `["args", "inputs", "outputs", "models", "enums"]`
 
-Delete all files in `output` folder  
+#### `omitModelsCount`
+Omit `_count` field from models.  
+Type: `boolean`  
+Default: `false`
+
+#### `purgeOutput`
+Delete all files in `output` folder.  
 Type: `boolean`  
 Default: `false`
 

--- a/src/handlers/model-output-type.ts
+++ b/src/handlers/model-output-type.ts
@@ -80,6 +80,8 @@ export function modelOutputType(outputType: OutputType, args: EventArguments) {
   importDeclarations.add('ObjectType', nestjsGraphql);
 
   for (const field of outputType.fields) {
+    if (config.omitModelsCount && field.name === '_count') continue;
+
     let fileType = 'model';
     const { location, isList, type, namespace } = field.outputType;
 

--- a/src/handlers/output-type.ts
+++ b/src/handlers/output-type.ts
@@ -26,6 +26,9 @@ export function outputType(outputType: OutputType, args: EventArguments) {
     String(outputType.name).startsWith(model.name);
   const isCountOutput =
     model?.name && outputType.name === `${model.name}CountOutputType`;
+
+  if (!config.emitBlocks.outputs && !isCountOutput) return;
+
   // Get rid of bogus suffixes
   outputType.name = getOutputTypeName(outputType.name);
 

--- a/src/handlers/register-enum.ts
+++ b/src/handlers/register-enum.ts
@@ -4,7 +4,10 @@ import { ImportDeclarationMap } from '../helpers/import-declaration-map';
 import { EventArguments, SchemaEnum } from '../types';
 
 export function registerEnum(enumType: SchemaEnum, args: EventArguments) {
-  const { getSourceFile, enums } = args;
+  const { getSourceFile, enums, config } = args;
+
+  if (!config.emitBlocks.prismaEnums && !enums[enumType.name]) return;
+
   const dataModelEnum = enums[enumType.name];
   const sourceFile = getSourceFile({
     name: enumType.name,

--- a/src/helpers/create-config.spec.ts
+++ b/src/helpers/create-config.spec.ts
@@ -94,4 +94,48 @@ describe('createConfig', () => {
 
     expect(result.tsConfigFilePath).toEqual('tsconfig.json');
   });
+
+  it('emitBlocks default', () => {
+    const result = createConfig({});
+
+    expect(result.emitBlocks.args).toEqual(true);
+    expect(result.emitBlocks.models).toEqual(true);
+    expect(result.emitBlocks.inputs).toEqual(true);
+    expect(result.emitBlocks.outputs).toEqual(true);
+    expect(result.emitBlocks.prismaEnums).toEqual(true);
+    expect(result.emitBlocks.schemaEnums).toEqual(true);
+  });
+
+  it('emitBlocks with models only', () => {
+    const result = createConfig({ emitBlocks: ['models'] });
+
+    expect(result.emitBlocks.args).toBeUndefined();
+    expect(result.emitBlocks.models).toEqual(true);
+    expect(result.emitBlocks.inputs).toBeUndefined();
+    expect(result.emitBlocks.outputs).toBeUndefined();
+    expect(result.emitBlocks.prismaEnums).toBeUndefined();
+    expect(result.emitBlocks.schemaEnums).toEqual(true);
+  });
+
+  it('emitBlocks with inputs only', () => {
+    const result = createConfig({ emitBlocks: ['inputs'] });
+
+    expect(result.emitBlocks.args).toBeUndefined();
+    expect(result.emitBlocks.models).toBeUndefined();
+    expect(result.emitBlocks.inputs).toEqual(true);
+    expect(result.emitBlocks.outputs).toBeUndefined();
+    expect(result.emitBlocks.prismaEnums).toEqual(true);
+    expect(result.emitBlocks.schemaEnums).toBeUndefined();
+  });
+
+  it('emitBlocks with enums only', () => {
+    const result = createConfig({ emitBlocks: ['enums'] });
+
+    expect(result.emitBlocks.args).toBeUndefined();
+    expect(result.emitBlocks.models).toBeUndefined();
+    expect(result.emitBlocks.inputs).toBeUndefined();
+    expect(result.emitBlocks.outputs).toBeUndefined();
+    expect(result.emitBlocks.prismaEnums).toEqual(true);
+    expect(result.emitBlocks.schemaEnums).toEqual(true);
+  });
 });

--- a/src/helpers/create-config.ts
+++ b/src/helpers/create-config.ts
@@ -8,6 +8,7 @@ import outmatch from 'outmatch';
 
 import { ReExport } from '../handlers/re-export';
 import { ImportNameSpec, ObjectSetting } from '../types';
+import { createEmitBlocks, EmitBlocksOption } from './create-emit-blocks';
 
 type ConfigFieldSetting = Partial<Omit<ObjectSetting, 'name'>>;
 type DecorateElement = {
@@ -103,6 +104,8 @@ export function createConfig(data: Record<string, unknown>) {
     reExport: (ReExport[String(config.reExport)] || ReExport.None) as ReExport,
     emitSingle: toBoolean(config.emitSingle),
     emitCompiled: toBoolean(config.emitCompiled),
+    emitBlocks: createEmitBlocks(config.emitBlocks as EmitBlocksOption[]),
+    omitModelsCount: toBoolean(config.omitModelsCount),
     $warnings,
     fields,
     purgeOutput: toBoolean(config.purgeOutput),

--- a/src/helpers/create-emit-blocks.ts
+++ b/src/helpers/create-emit-blocks.ts
@@ -1,0 +1,43 @@
+type EmittedBlockType =
+  | 'prismaEnums'
+  | 'schemaEnums'
+  | 'models'
+  | 'inputs'
+  | 'args'
+  | 'outputs'
+
+export type EmitBlocksOption =
+  | 'enums'
+  | 'models'
+  | 'inputs'
+  | 'args'
+  | 'outputs'
+
+const allEmmittedBlocks: EmittedBlockType[] = ['prismaEnums', 'schemaEnums', 'models', 'inputs', 'args', 'outputs'];
+
+const blocksDependencyMap: Record<EmitBlocksOption, EmittedBlockType[]> = {
+  enums: ['schemaEnums', 'prismaEnums'],
+  models: ['models', 'schemaEnums'],
+  inputs: ['inputs', 'prismaEnums'],
+  outputs: ['outputs'],
+  args: ['args', 'inputs', 'prismaEnums']
+};
+
+export function createEmitBlocks(data?: string[]): Record<EmittedBlockType, boolean> {
+  if (!data) {
+    return Object.fromEntries(allEmmittedBlocks.map(block => [block, true])) as Record<EmittedBlockType, boolean>;
+  }
+
+  let blocksToEmit = {} as Record<EmittedBlockType, boolean>;
+
+  for (const block of data) {
+    if (!Object.keys(blocksDependencyMap).includes(block as any)) continue;
+
+    blocksToEmit = {
+      ...blocksToEmit,
+      ...Object.fromEntries((blocksDependencyMap[block] as EmittedBlockType[]).map(block => [block, true]))
+    };
+  }
+
+  return blocksToEmit;
+}

--- a/src/helpers/get-graphql-input-type.ts
+++ b/src/helpers/get-graphql-input-type.ts
@@ -7,10 +7,10 @@ import { DMMF } from '../types';
  * Find input type for graphql field decorator.
  */
 export function getGraphqlInputType(
-  inputTypes: DMMF.SchemaArgInputType[],
+  inputTypes: DMMF.InputTypeRef[],
   pattern?: string,
 ) {
-  let result: DMMF.SchemaArgInputType | undefined;
+  let result: DMMF.InputTypeRef | undefined;
 
   inputTypes = inputTypes.filter(t => !['null', 'Null'].includes(String(t.type)));
   inputTypes = uniqWith(inputTypes, isEqual);


### PR DESCRIPTION
Adds two new options to config:
- `emitBlocks`
Emit only selected blocks. Be aware, that some blocks do depend on others, e.g. one can't emit `models` without emitting `enums`.  
Type: `("args" | "inputs" | "outputs" | "models" | "enums")[]`  
Default: `["args", "inputs", "outputs", "models", "enums"]`
- `omitModelsCount`
Omit `_count` field from models.  
Type: `boolean`  
Default: `false`