### PR TITLE
Upgraded to prisma 5.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     }
   },
   "dependencies": {
-    "@prisma/generator-helper": "^5.7.0",
+    "@prisma/generator-helper": "^5.11.0",
     "await-event-emitter": "^2.0.2",
     "filenamify": "4.X",
     "flat": "5.X",
@@ -80,7 +80,8 @@
     "outmatch": "^0.7.0",
     "pluralize": "^8.0.0",
     "pupa": "2.X",
-    "ts-morph": ">=11 <=16"
+    "ts-morph": ">=11 <=16",
+    "type-fest": "4.13.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^18.4.3",
@@ -91,7 +92,7 @@
     "@nestjs/graphql": "^12.0.11",
     "@nestjs/platform-express": "^10.2.10",
     "@paljs/plugins": "^6.0.7",
-    "@prisma/client": "^5.7.0",
+    "@prisma/client": "^5.11.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^9.2.5",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
       ]
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "test": "npm run eslint && npm run tscheck && npm run test:cov",
     "mocha": "node node_modules/mocha/bin/mocha",

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -32,6 +32,7 @@ import {
 const AwaitEventEmitter = require('await-event-emitter').default;
 
 import AEE from 'await-event-emitter';
+import { WritableDeep } from 'type-fest';
 
 export async function generate(
   args: GeneratorOptions & {
@@ -107,7 +108,7 @@ export async function generate(
     outputFilePattern: config.outputFilePattern,
     eventEmitter,
   });
-  const { datamodel, schema } = JSON.parse(JSON.stringify(dmmf)) as DMMF.Document;
+  const { datamodel, schema } = JSON.parse(JSON.stringify(dmmf)) as WritableDeep<DMMF.Document>;
   const removeTypes = new Set<string>();
   const eventArguments: EventArguments = {
     schema,

--- a/src/handlers/combine-scalar-filters.ts
+++ b/src/handlers/combine-scalar-filters.ts
@@ -3,6 +3,7 @@ import { cloneDeep, keyBy, remove } from 'lodash';
 
 import { BeforeGenerateField } from '../event-names';
 import { DMMF, EventArguments, InputType } from '../types';
+import { WritableDeep } from 'type-fest';
 
 /**
  * Subscribes on 'BeforeInputType'
@@ -28,7 +29,7 @@ function beforeInputType(
   }
 }
 
-function beforeGenerateField(field: DMMF.SchemaArg): void {
+function beforeGenerateField(field: WritableDeep<DMMF.SchemaArg>): void {
   for (const fieldInput of field.inputTypes) {
     if (fieldInput.location !== 'inputObjectTypes') {
       continue;

--- a/src/handlers/emit-single.ts
+++ b/src/handlers/emit-single.ts
@@ -22,7 +22,20 @@ function classProperty(
       propertyType,
       t => t === 'null' || t.startsWith('Prisma.'),
     );
-    const mappedInstanceofTypes = instanceofTypes.map(t => `InstanceType<typeof ${t}>`);
+    const mappedInstanceofTypes = instanceofTypes.map((t) => {
+      if (t.endsWith(`RelationFilter`)) {
+          let whereInput;
+          if (isList) {
+              whereInput = whereInput.replace(`RelationFilter`, `WhereInput`);
+          } else {
+              whereInput = t.replace(`ListRelationFilter`, `WhereInput`);
+          }
+
+          return `XOR<InstanceType<typeof ${t}>, ${whereInput}>`;
+      }
+
+      return `InstanceType<typeof ${t}>`;
+  });
 
     property.type = [...mappedInstanceofTypes, ...safeTypes].join(' | ');
   }

--- a/src/handlers/model-data.ts
+++ b/src/handlers/model-data.ts
@@ -1,7 +1,8 @@
+import { WritableDeep } from 'type-fest';
 import { createObjectSettings, ObjectSettings } from '../helpers/object-settings';
 import { DMMF, EventArguments, Field } from '../types';
 
-export function modelData(model: DMMF.Model, args: EventArguments) {
+export function modelData(model: WritableDeep<DMMF.Model>, args: EventArguments) {
   const {
     config,
     modelNames,

--- a/src/helpers/get-where-unique-at-least-keys.ts
+++ b/src/helpers/get-where-unique-at-least-keys.ts
@@ -1,6 +1,6 @@
-import { DMMF } from '../types';
+import { Model } from '../types';
 
-export function getWhereUniqueAtLeastKeys(model: DMMF.Model) {
+export function getWhereUniqueAtLeastKeys(model: Model) {
   const names = model.fields
     .filter(field => field.isUnique || field.isId)
     .map(field => field.name);

--- a/src/helpers/property-structure.ts
+++ b/src/helpers/property-structure.ts
@@ -21,7 +21,7 @@ export function propertyStructure(args: {
   } = args;
   const type = propertyType.map(type2 => {
     if (isList) {
-        if (name === `AND`) {
+        if (name === `AND` || name === `NOT`) {
             return `Array<${type2}> | ${type2}`;
         }
 

--- a/src/helpers/property-structure.ts
+++ b/src/helpers/property-structure.ts
@@ -19,7 +19,17 @@ export function propertyStructure(args: {
     hasQuestionToken,
     hasExclamationToken,
   } = args;
-  const type = propertyType.map(type => (isList ? `Array<${type}>` : type)).join(' | ');
+  const type = propertyType.map(type2 => {
+    if (isList) {
+        if (name === `AND`) {
+            return `Array<${type2}> | ${type2}`;
+        }
+
+        return `Array<${type2}>`;
+    }
+
+    return type2;
+  }).join(' | ');
 
   return {
     kind: StructureKind.Property,

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,13 +4,14 @@ import { Project, SourceFile } from 'ts-morph';
 
 import { createConfig } from './helpers/create-config';
 import { ObjectSettings } from './helpers/object-settings';
+import { WritableDeep } from 'type-fest';
 
-export type InputType = DMMF.InputType;
+export type InputType = WritableDeep<DMMF.InputType>;
 export type FieldLocation = DMMF.FieldLocation;
-export type OutputType = DMMF.OutputType;
-export type SchemaField = DMMF.SchemaField;
+export type OutputType = WritableDeep<DMMF.OutputType>;
+export type SchemaField = WritableDeep<DMMF.SchemaField>;
 export type SchemaEnum = DMMF.SchemaEnum;
-export type Model = DMMF.Model;
+export type Model = WritableDeep<DMMF.Model>;
 
 export type FieldOutputType = SchemaField['outputType'];
 
@@ -28,7 +29,7 @@ export type TypeRecord = Partial<{
 export type GeneratorConfiguration = ReturnType<typeof createConfig>;
 
 export type EventArguments = {
-  schema: DMMF.Schema;
+  schema: WritableDeep<DMMF.Schema>;
   models: Map<string, Model>;
   modelNames: string[];
   modelFields: Map<string, Map<string, Field>>;


### PR DESCRIPTION
### Major changes
- Prisma added `ReadonlyDeep` type which was causing TypeScript to throw errors. To counter that I mapped types with `WritableDeep` from `type-fest` library.
- Prisma `AND` and `NOT` fields now also allow single element instead of an Array, which was causing incompatibility between prisma and generators.
- Prisma relation fields are now `XOR` of `RelationField` and `WhereInput`.