### PR TITLE
feat: support default value for Json type.

### DIFF
--- a/@generated/dummy/dummy-count-aggregate.input.ts
+++ b/@generated/dummy/dummy-count-aggregate.input.ts
@@ -31,6 +31,9 @@ export class DummyCountAggregateInput {
   json?: true;
 
   @Field(() => Boolean, { nullable: true })
+  jsonDefault?: true;
+
+  @Field(() => Boolean, { nullable: true })
   friends?: true;
 
   @Field(() => Boolean, { nullable: true })

--- a/@generated/dummy/dummy-count-aggregate.output.ts
+++ b/@generated/dummy/dummy-count-aggregate.output.ts
@@ -1,6 +1,7 @@
 import { Field } from '@nestjs/graphql';
 import { ObjectType } from '@nestjs/graphql';
 import { Int } from '@nestjs/graphql';
+import * as Types from '../../example/dummy/dummy.types';
 
 @ObjectType()
 export class DummyCountAggregate {
@@ -30,6 +31,9 @@ export class DummyCountAggregate {
 
   @Field(() => Int, { nullable: false })
   json!: number;
+
+  @Field(() => Int, { nullable: false })
+  jsonDefault!: Types.DummyJsonType;
 
   @Field(() => Int, { nullable: false })
   friends!: number;

--- a/@generated/dummy/dummy-count-order-by-aggregate.input.ts
+++ b/@generated/dummy/dummy-count-order-by-aggregate.input.ts
@@ -32,5 +32,8 @@ export class DummyCountOrderByAggregateInput {
   json?: keyof typeof SortOrder;
 
   @Field(() => SortOrder, { nullable: true })
+  jsonDefault?: keyof typeof SortOrder;
+
+  @Field(() => SortOrder, { nullable: true })
   friends?: keyof typeof SortOrder;
 }

--- a/@generated/dummy/dummy-create-many.input.ts
+++ b/@generated/dummy/dummy-create-many.input.ts
@@ -43,6 +43,9 @@ export class DummyCreateManyInput {
   @Field(() => GraphQLJSON, { nullable: true })
   json?: any;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  jsonDefault?: any;
+
   @Field(() => DummyCreatefriendsInput, { nullable: true })
   @Type(() => DummyCreatefriendsInput)
   friends?: DummyCreatefriendsInput;

--- a/@generated/dummy/dummy-create.input.ts
+++ b/@generated/dummy/dummy-create.input.ts
@@ -43,6 +43,9 @@ export class DummyCreateInput {
   @Field(() => GraphQLJSON, { nullable: true })
   json?: any;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  jsonDefault?: any;
+
   @Field(() => DummyCreatefriendsInput, { nullable: true })
   @Type(() => DummyCreatefriendsInput)
   friends?: DummyCreatefriendsInput;

--- a/@generated/dummy/dummy-group-by.output.ts
+++ b/@generated/dummy/dummy-group-by.output.ts
@@ -5,6 +5,7 @@ import { Float } from '@nestjs/graphql';
 import { Decimal } from '@prisma/client/runtime/library';
 import { GraphQLDecimal } from 'prisma-graphql-type-decimal';
 import { GraphQLJSON } from 'graphql-type-json';
+import * as Types from '../../example/dummy/dummy.types';
 import { DummyCountAggregate } from './dummy-count-aggregate.output';
 import { DummyAvgAggregate } from './dummy-avg-aggregate.output';
 import { DummySumAggregate } from './dummy-sum-aggregate.output';
@@ -39,6 +40,9 @@ export class DummyGroupBy {
 
   @Field(() => GraphQLJSON, { nullable: true })
   json?: any;
+
+  @Field(() => Types.DummyJsonType, { nullable: false })
+  jsonDefault!: Types.DummyJsonType;
 
   @Field(() => [String], { nullable: true })
   friends?: Array<string>;

--- a/@generated/dummy/dummy-order-by-with-aggregation.input.ts
+++ b/@generated/dummy/dummy-order-by-with-aggregation.input.ts
@@ -39,6 +39,9 @@ export class DummyOrderByWithAggregationInput {
   json?: SortOrderInput;
 
   @Field(() => SortOrder, { nullable: true })
+  jsonDefault?: keyof typeof SortOrder;
+
+  @Field(() => SortOrder, { nullable: true })
   friends?: keyof typeof SortOrder;
 
   @Field(() => DummyCountOrderByAggregateInput, { nullable: true })

--- a/@generated/dummy/dummy-order-by-with-relation-and-search-relevance.input.ts
+++ b/@generated/dummy/dummy-order-by-with-relation-and-search-relevance.input.ts
@@ -35,6 +35,9 @@ export class DummyOrderByWithRelationAndSearchRelevanceInput {
   json?: SortOrderInput;
 
   @Field(() => SortOrder, { nullable: true })
+  jsonDefault?: keyof typeof SortOrder;
+
+  @Field(() => SortOrder, { nullable: true })
   friends?: keyof typeof SortOrder;
 
   @Field(() => DummyOrderByRelevanceInput, { nullable: true })

--- a/@generated/dummy/dummy-scalar-field.enum.ts
+++ b/@generated/dummy/dummy-scalar-field.enum.ts
@@ -10,6 +10,7 @@ export enum DummyScalarFieldEnum {
   decimals = 'decimals',
   bigInt = 'bigInt',
   json = 'json',
+  jsonDefault = 'jsonDefault',
   friends = 'friends',
 }
 

--- a/@generated/dummy/dummy-scalar-where-with-aggregates.input.ts
+++ b/@generated/dummy/dummy-scalar-where-with-aggregates.input.ts
@@ -10,6 +10,7 @@ import { DecimalWithAggregatesFilter } from '../prisma/decimal-with-aggregates-f
 import { DecimalNullableListFilter } from '../prisma/decimal-nullable-list-filter.input';
 import { BigIntNullableWithAggregatesFilter } from '../prisma/big-int-nullable-with-aggregates-filter.input';
 import { JsonNullableWithAggregatesFilter } from '../prisma/json-nullable-with-aggregates-filter.input';
+import { JsonWithAggregatesFilter } from '../prisma/json-with-aggregates-filter.input';
 import { StringNullableListFilter } from '../prisma/string-nullable-list-filter.input';
 
 @InputType()
@@ -54,6 +55,9 @@ export class DummyScalarWhereWithAggregatesInput {
 
   @Field(() => JsonNullableWithAggregatesFilter, { nullable: true })
   json?: JsonNullableWithAggregatesFilter;
+
+  @Field(() => JsonWithAggregatesFilter, { nullable: true })
+  jsonDefault?: JsonWithAggregatesFilter;
 
   @Field(() => StringNullableListFilter, { nullable: true })
   friends?: StringNullableListFilter;

--- a/@generated/dummy/dummy-unchecked-create.input.ts
+++ b/@generated/dummy/dummy-unchecked-create.input.ts
@@ -43,6 +43,9 @@ export class DummyUncheckedCreateInput {
   @Field(() => GraphQLJSON, { nullable: true })
   json?: any;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  jsonDefault?: any;
+
   @Field(() => DummyCreatefriendsInput, { nullable: true })
   @Type(() => DummyCreatefriendsInput)
   friends?: DummyCreatefriendsInput;

--- a/@generated/dummy/dummy-unchecked-update-many.input.ts
+++ b/@generated/dummy/dummy-unchecked-update-many.input.ts
@@ -43,6 +43,9 @@ export class DummyUncheckedUpdateManyInput {
   @Field(() => GraphQLJSON, { nullable: true })
   json?: any;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  jsonDefault?: any;
+
   @Field(() => DummyUpdatefriendsInput, { nullable: true })
   @Type(() => DummyUpdatefriendsInput)
   friends?: DummyUpdatefriendsInput;

--- a/@generated/dummy/dummy-unchecked-update.input.ts
+++ b/@generated/dummy/dummy-unchecked-update.input.ts
@@ -43,6 +43,9 @@ export class DummyUncheckedUpdateInput {
   @Field(() => GraphQLJSON, { nullable: true })
   json?: any;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  jsonDefault?: any;
+
   @Field(() => DummyUpdatefriendsInput, { nullable: true })
   @Type(() => DummyUpdatefriendsInput)
   friends?: DummyUpdatefriendsInput;

--- a/@generated/dummy/dummy-update-many-mutation.input.ts
+++ b/@generated/dummy/dummy-update-many-mutation.input.ts
@@ -43,6 +43,9 @@ export class DummyUpdateManyMutationInput {
   @Field(() => GraphQLJSON, { nullable: true })
   json?: any;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  jsonDefault?: any;
+
   @Field(() => DummyUpdatefriendsInput, { nullable: true })
   @Type(() => DummyUpdatefriendsInput)
   friends?: DummyUpdatefriendsInput;

--- a/@generated/dummy/dummy-update.input.ts
+++ b/@generated/dummy/dummy-update.input.ts
@@ -43,6 +43,9 @@ export class DummyUpdateInput {
   @Field(() => GraphQLJSON, { nullable: true })
   json?: any;
 
+  @Field(() => GraphQLJSON, { nullable: true })
+  jsonDefault?: any;
+
   @Field(() => DummyUpdatefriendsInput, { nullable: true })
   @Type(() => DummyUpdatefriendsInput)
   friends?: DummyUpdatefriendsInput;

--- a/@generated/dummy/dummy-where-unique.input.ts
+++ b/@generated/dummy/dummy-where-unique.input.ts
@@ -10,6 +10,7 @@ import { DecimalFilter } from '../prisma/decimal-filter.input';
 import { DecimalNullableListFilter } from '../prisma/decimal-nullable-list-filter.input';
 import { BigIntNullableFilter } from '../prisma/big-int-nullable-filter.input';
 import { JsonNullableFilter } from '../prisma/json-nullable-filter.input';
+import { JsonFilter } from '../prisma/json-filter.input';
 import { StringNullableListFilter } from '../prisma/string-nullable-list-filter.input';
 
 @InputType()
@@ -54,6 +55,9 @@ export class DummyWhereUniqueInput {
 
   @Field(() => JsonNullableFilter, { nullable: true })
   json?: JsonNullableFilter;
+
+  @Field(() => JsonFilter, { nullable: true })
+  jsonDefault?: JsonFilter;
 
   @Field(() => StringNullableListFilter, { nullable: true })
   friends?: StringNullableListFilter;

--- a/@generated/dummy/dummy-where.input.ts
+++ b/@generated/dummy/dummy-where.input.ts
@@ -10,6 +10,7 @@ import { DecimalFilter } from '../prisma/decimal-filter.input';
 import { DecimalNullableListFilter } from '../prisma/decimal-nullable-list-filter.input';
 import { BigIntNullableFilter } from '../prisma/big-int-nullable-filter.input';
 import { JsonNullableFilter } from '../prisma/json-nullable-filter.input';
+import { JsonFilter } from '../prisma/json-filter.input';
 import { StringNullableListFilter } from '../prisma/string-nullable-list-filter.input';
 
 @InputType()
@@ -54,6 +55,9 @@ export class DummyWhereInput {
 
   @Field(() => JsonNullableFilter, { nullable: true })
   json?: JsonNullableFilter;
+
+  @Field(() => JsonFilter, { nullable: true })
+  jsonDefault?: JsonFilter;
 
   @Field(() => StringNullableListFilter, { nullable: true })
   friends?: StringNullableListFilter;

--- a/@generated/dummy/dummy.model.ts
+++ b/@generated/dummy/dummy.model.ts
@@ -6,6 +6,7 @@ import { Float } from '@nestjs/graphql';
 import { GraphQLDecimal } from 'prisma-graphql-type-decimal';
 import { Decimal } from '@prisma/client/runtime/library';
 import { GraphQLJSON } from 'graphql-type-json';
+import * as Types from '../../example/dummy/dummy.types';
 
 @ObjectType()
 export class Dummy {
@@ -35,6 +36,9 @@ export class Dummy {
 
   @Field(() => GraphQLJSON, { nullable: true })
   json!: any | null;
+
+  @Field(() => Types.DummyJsonType, { nullable: false, defaultValue: { foo: 'bar' } })
+  jsonDefault!: Types.DummyJsonType;
 
   @Field(() => [String], { nullable: true })
   friends!: Array<string>;

--- a/@generated/prisma/json-filter.input.ts
+++ b/@generated/prisma/json-filter.input.ts
@@ -1,0 +1,45 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { GraphQLJSON } from 'graphql-type-json';
+
+@InputType()
+export class JsonFilter {
+  @Field(() => GraphQLJSON, { nullable: true })
+  equals?: any;
+
+  @Field(() => [String], { nullable: true })
+  path?: Array<string>;
+
+  @Field(() => String, { nullable: true })
+  string_contains?: string;
+
+  @Field(() => String, { nullable: true })
+  string_starts_with?: string;
+
+  @Field(() => String, { nullable: true })
+  string_ends_with?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  array_contains?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  array_starts_with?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  array_ends_with?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  lt?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  lte?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  gt?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  gte?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  not?: any;
+}

--- a/@generated/prisma/json-null-value-input.enum.ts
+++ b/@generated/prisma/json-null-value-input.enum.ts
@@ -1,0 +1,10 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum JsonNullValueInput {
+  JsonNull = 'JsonNull',
+}
+
+registerEnumType(JsonNullValueInput, {
+  name: 'JsonNullValueInput',
+  description: undefined,
+});

--- a/@generated/prisma/json-with-aggregates-filter.input.ts
+++ b/@generated/prisma/json-with-aggregates-filter.input.ts
@@ -1,0 +1,56 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { GraphQLJSON } from 'graphql-type-json';
+import { NestedIntFilter } from './nested-int-filter.input';
+import { NestedJsonFilter } from './nested-json-filter.input';
+
+@InputType()
+export class JsonWithAggregatesFilter {
+  @Field(() => GraphQLJSON, { nullable: true })
+  equals?: any;
+
+  @Field(() => [String], { nullable: true })
+  path?: Array<string>;
+
+  @Field(() => String, { nullable: true })
+  string_contains?: string;
+
+  @Field(() => String, { nullable: true })
+  string_starts_with?: string;
+
+  @Field(() => String, { nullable: true })
+  string_ends_with?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  array_contains?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  array_starts_with?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  array_ends_with?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  lt?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  lte?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  gt?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  gte?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  not?: any;
+
+  @Field(() => NestedIntFilter, { nullable: true })
+  _count?: NestedIntFilter;
+
+  @Field(() => NestedJsonFilter, { nullable: true })
+  _min?: NestedJsonFilter;
+
+  @Field(() => NestedJsonFilter, { nullable: true })
+  _max?: NestedJsonFilter;
+}

--- a/@generated/prisma/nested-json-filter.input.ts
+++ b/@generated/prisma/nested-json-filter.input.ts
@@ -1,0 +1,45 @@
+import { Field } from '@nestjs/graphql';
+import { InputType } from '@nestjs/graphql';
+import { GraphQLJSON } from 'graphql-type-json';
+
+@InputType()
+export class NestedJsonFilter {
+  @Field(() => GraphQLJSON, { nullable: true })
+  equals?: any;
+
+  @Field(() => [String], { nullable: true })
+  path?: Array<string>;
+
+  @Field(() => String, { nullable: true })
+  string_contains?: string;
+
+  @Field(() => String, { nullable: true })
+  string_starts_with?: string;
+
+  @Field(() => String, { nullable: true })
+  string_ends_with?: string;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  array_contains?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  array_starts_with?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  array_ends_with?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  lt?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  lte?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  gt?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  gte?: any;
+
+  @Field(() => GraphQLJSON, { nullable: true })
+  not?: any;
+}

--- a/example/dummy/dummy.types.ts
+++ b/example/dummy/dummy.types.ts
@@ -1,0 +1,7 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+@ObjectType()
+export class DummyJsonType {
+  @Field(() => String, { nullable: false })
+  foo!: string;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,8 @@ generator nestgraphql {
   fields_Validator_input                = true
   fields_Scalars_from                   = "graphql-scalars"
   fields_Scalars_input                  = true
+  fields_Types_from                     = "../../example/dummy/dummy.types"
+  fields_Types_output                   = true
   useInputType_WhereInput_ALL           = "WhereInput"
   decorate_1_type                       = "Create@(One|Many)UserArgs"
   decorate_1_field                      = data
@@ -116,14 +118,17 @@ model Profile {
 }
 
 model Dummy {
-  id       String    @id
-  date     DateTime? @default(now())
-  int      Int?
-  float    Float?
-  bytes    Bytes?
-  decimal  Decimal // Keep as required (for compatibility check)
-  decimals Decimal[]
-  bigInt   BigInt?
-  json     Json?
-  friends  String[]
+  id          String    @id
+  date        DateTime? @default(now())
+  int         Int?
+  float       Float?
+  bytes       Bytes?
+  decimal     Decimal // Keep as required (for compatibility check)
+  decimals    Decimal[]
+  bigInt      BigInt?
+  json        Json?
+  /// @FieldType('Types.DummyJsonType')
+  /// @PropertyType('Types.DummyJsonType')
+  jsonDefault Json      @default("{\"foo\":\"bar\"}")
+  friends     String[]
 }

--- a/src/handlers/model-output-type.ts
+++ b/src/handlers/model-output-type.ts
@@ -188,7 +188,9 @@ export function modelOutputType(outputType: OutputType, args: EventArguments) {
             defaultValue: ['number', 'string', 'boolean'].includes(
               typeof modelField?.default,
             )
-              ? modelField?.default
+              ? modelField?.type == 'Json' && typeof modelField?.default == 'string'
+                ? JSON5.parse(modelField?.default)
+                : modelField?.default
               : undefined,
             description: modelField?.documentation,
           }),


### PR DESCRIPTION
For the following schema
```
model Dummy {
  id          String    @id
  /// @FieldType('Types.DummyJsonType')
  /// @PropertyType('Types.DummyJsonType')
  jsonDefault Json      @default("{\"foo\":\"bar\"}")
}
```
In previous versions, this code with errors would be generated:
```TypeScript
@ObjectType()
export class Dummy {
    @Field(() => ID, { nullable: false })
    id!: string;

    @Field(() => Types.DummyJsonType, {nullable:false,defaultValue:'{"foo":"bar"}'})
    //                                                ^Type ‘string’ is not assignable to type ‘DummyJsonType’
    jsonDefault!: Types.DummyJsonType;
}
```

In this PR, code like this will be generated:
```TypeScript
@ObjectType()
export class Dummy {
    @Field(() => ID, { nullable: false })
    id!: string;

    @Field(() => Types.DummyJsonType, { nullable: false, defaultValue: { foo: 'bar' } })
    jsonDefault!: Types.DummyJsonType;
}
```