### PR TITLE
feat: :sparkles: add enum value-level descriptions and deprecation me…

### DIFF
--- a/@generated/user/user-update-without-articles.input.ts
+++ b/@generated/user/user-update-without-articles.input.ts
@@ -15,54 +15,55 @@ import { ProfileUpdateOneWithoutUserNestedInput } from '../profile/profile-updat
 
 @InputType()
 export class UserUpdateWithoutArticlesInput {
-  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  id?: StringFieldUpdateOperationsInput;
 
-  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  email?: StringFieldUpdateOperationsInput;
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    id?: StringFieldUpdateOperationsInput;
 
-  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  name?: StringFieldUpdateOperationsInput;
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    email?: StringFieldUpdateOperationsInput;
 
-  @Field(() => StringFieldUpdateOperationsInput, { nullable: true })
-  password?: StringFieldUpdateOperationsInput;
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    name?: StringFieldUpdateOperationsInput;
 
-  @Field(() => NullableStringFieldUpdateOperationsInput, { nullable: true })
-  bio?: NullableStringFieldUpdateOperationsInput;
+    @Field(() => StringFieldUpdateOperationsInput, {nullable:true})
+    password?: StringFieldUpdateOperationsInput;
 
-  @Field(() => NullableStringFieldUpdateOperationsInput, { nullable: true })
-  image?: NullableStringFieldUpdateOperationsInput;
+    @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
+    bio?: NullableStringFieldUpdateOperationsInput;
 
-  @Field(() => NullableIntFieldUpdateOperationsInput, { nullable: true })
-  countComments?: NullableIntFieldUpdateOperationsInput;
+    @Field(() => NullableStringFieldUpdateOperationsInput, {nullable:true})
+    image?: NullableStringFieldUpdateOperationsInput;
 
-  @Field(() => NullableFloatFieldUpdateOperationsInput, { nullable: true })
-  rating?: NullableFloatFieldUpdateOperationsInput;
+    @Field(() => NullableIntFieldUpdateOperationsInput, {nullable:true})
+    countComments?: NullableIntFieldUpdateOperationsInput;
 
-  @Field(() => NullableDecimalFieldUpdateOperationsInput, { nullable: true })
-  @Type(() => NullableDecimalFieldUpdateOperationsInput)
-  money?: NullableDecimalFieldUpdateOperationsInput;
+    @Field(() => NullableFloatFieldUpdateOperationsInput, {nullable:true})
+    rating?: NullableFloatFieldUpdateOperationsInput;
 
-  @Field(() => NullableEnumRoleFieldUpdateOperationsInput, { nullable: true })
-  role?: NullableEnumRoleFieldUpdateOperationsInput;
+    @Field(() => NullableDecimalFieldUpdateOperationsInput, {nullable:true})
+    @Type(() => NullableDecimalFieldUpdateOperationsInput)
+    money?: NullableDecimalFieldUpdateOperationsInput;
 
-  @Field(() => UserUpdateManyWithoutFollowersNestedInput, { nullable: true })
-  @Type(() => UserUpdateManyWithoutFollowersNestedInput)
-  following?: UserUpdateManyWithoutFollowersNestedInput;
+    @Field(() => NullableEnumRoleFieldUpdateOperationsInput, {nullable:true})
+    role?: NullableEnumRoleFieldUpdateOperationsInput;
 
-  @Field(() => UserUpdateManyWithoutFollowingNestedInput, { nullable: true })
-  @Type(() => UserUpdateManyWithoutFollowingNestedInput)
-  followers?: UserUpdateManyWithoutFollowingNestedInput;
+    @Field(() => UserUpdateManyWithoutFollowersNestedInput, {nullable:true})
+    @Type(() => UserUpdateManyWithoutFollowersNestedInput)
+    following?: UserUpdateManyWithoutFollowersNestedInput;
 
-  @Field(() => ArticleUpdateManyWithoutFavoritedByNestedInput, { nullable: true })
-  @Type(() => ArticleUpdateManyWithoutFavoritedByNestedInput)
-  favoriteArticles?: ArticleUpdateManyWithoutFavoritedByNestedInput;
+    @Field(() => UserUpdateManyWithoutFollowingNestedInput, {nullable:true})
+    @Type(() => UserUpdateManyWithoutFollowingNestedInput)
+    followers?: UserUpdateManyWithoutFollowingNestedInput;
 
-  @Field(() => CommentUpdateManyWithoutAuthorNestedInput, { nullable: true })
-  @Type(() => CommentUpdateManyWithoutAuthorNestedInput)
-  comments?: CommentUpdateManyWithoutAuthorNestedInput;
+    @Field(() => ArticleUpdateManyWithoutFavoritedByNestedInput, {nullable:true})
+    @Type(() => ArticleUpdateManyWithoutFavoritedByNestedInput)
+    favoriteArticles?: ArticleUpdateManyWithoutFavoritedByNestedInput;
 
-  @Field(() => ProfileUpdateOneWithoutUserNestedInput, { nullable: true })
-  @Type(() => ProfileUpdateOneWithoutUserNestedInput)
-  profile?: ProfileUpdateOneWithoutUserNestedInput;
+    @Field(() => CommentUpdateManyWithoutAuthorNestedInput, {nullable:true})
+    @Type(() => CommentUpdateManyWithoutAuthorNestedInput)
+    comments?: CommentUpdateManyWithoutAuthorNestedInput;
+
+    @Field(() => ProfileUpdateOneWithoutUserNestedInput, {nullable:true})
+    @Type(() => ProfileUpdateOneWithoutUserNestedInput)
+    profile?: ProfileUpdateOneWithoutUserNestedInput;
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,11 +104,19 @@ model Comment {
   articleId String?
 }
 
+/// user access control
 enum Role {
+  /// default user access control
   USER
+  /// have full access control
+  NINGA
+  /// @deprecated Use USER instead
+  ADMIN
+  REVIEWER // no comment and won't show in registerenum valuemaps
 }
 
 model Profile {
+  /// @deprecated Use new name instead
   id     Int     @id @default(autoincrement())
   user   User    @relation(fields: [userId], references: [id])
   userId String  @unique

--- a/src/handlers/prisma-enum-doc.ts
+++ b/src/handlers/prisma-enum-doc.ts
@@ -1,0 +1,24 @@
+// utils/prisma-enum-doc.ts
+
+type EnumValueDocInfo = { description: string } | { deprecationReason: string };
+
+export function extractEnumValueDocs(
+  values: readonly { name: string; [key: string]: any }[],
+): Record<string, EnumValueDocInfo> {
+  return Object.fromEntries(
+    values
+      .map((value): [string, EnumValueDocInfo] | null => {
+        const { name } = value;
+        const documentation: unknown = value.documentation;
+
+        if (typeof documentation !== 'string') return null;
+
+        if (documentation.startsWith('@deprecated')) {
+          return [name, { deprecationReason: documentation.slice(11).trim() }];
+        }
+
+        return [name, { description: documentation }];
+      })
+      .filter((entry): entry is [string, EnumValueDocInfo] => entry !== null),
+  );
+}


### PR DESCRIPTION
This update enhances the registerEnum function to support richer metadata for enum values using registerEnumType from @nestjs/graphql.

✅ Features
	•	Adds a valuesMap derived from SchemaEnum value documentation (e.g., comments in schema.prisma)
	•	Parses @deprecated annotations to set deprecationReason
	•	Uses regular comments as description
	•	Skips enum values without comments
	•	Introduces extractEnumValueDocs helper to encapsulate parsing logic