### PR TITLE
fix: emit middleware as identifier references instead of string literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,40 @@ fieldDecoratorArguments: [
 - `deprecationReason` — Mark field as deprecated
 - `name` — Custom name for the field in GraphQL schema (TypeScript property name stays the same)
 - `complexity` — Complexity value for query cost analysis
-- `middleware` — Array of field middleware functions
+- `middleware` — Middleware function name(s) to apply to the field
+
+**Middleware Example:**
+
+To use field middleware, combine `customImports` with `fieldDecoratorArguments`. Middleware values are emitted as identifier references (not string literals), allowing them to reference your imported middleware functions:
+
+```js
+export default {
+  customImports: [
+    { from: './middleware/logger', name: 'loggerMiddleware', defaultImport: true },
+    { from: './middleware/auth', name: 'authMiddleware', defaultImport: true },
+  ],
+  fieldDecoratorArguments: [
+    {
+      match: ({ objectName, propertyName }) =>
+        objectName === 'User' && propertyName === 'email',
+      decoratorArguments: {
+        middleware: ['loggerMiddleware', 'authMiddleware'],
+        description: 'User email with logging and auth',
+      },
+    },
+  ],
+};
+```
+
+This generates:
+
+```ts
+@Field(() => String, {
+  description: 'User email with logging and auth',
+  middleware: [loggerMiddleware, authMiddleware]
+})
+email: string;
+```
 
 **Note:** When using the `name` option to override a field name in GraphQL, ensure you understand Prisma field mapping. For example, if you override the `take` field name to `first`, you must update any Prisma query logic that references the field by its original name. Consider using a mapping helper if doing this across multiple queries.
 

--- a/src/handlers/input-type.ts
+++ b/src/handlers/input-type.ts
@@ -1,5 +1,4 @@
 import { ok } from 'assert';
-import JSON5 from 'json5';
 import pupa from 'pupa';
 import { type ClassDeclarationStructure, StructureKind } from 'ts-morph';
 
@@ -11,7 +10,7 @@ import { getWhereUniqueAtLeastKeys } from '../helpers/get-where-unique-at-least-
 import { ImportDeclarationMap } from '../helpers/import-declaration-map.ts';
 import { propertyStructure } from '../helpers/property-structure.ts';
 import { isWhereUniqueInputType } from '../helpers/type-checkers.ts';
-import { castArray, last } from '../helpers/utils.ts';
+import { castArray, last, stringifyFieldOptions } from '../helpers/utils.ts';
 import type { EventArguments, FieldInfo, InputType } from '../types.ts';
 
 export function inputType(
@@ -202,7 +201,7 @@ export function inputType(
       property.decorators.push({
         arguments: [
           isList ? `() => [${graphqlType}]` : `() => ${graphqlType}`,
-          JSON5.stringify({
+          stringifyFieldOptions({
             ...settings?.fieldArguments(),
             nullable: !isRequired,
             ...fieldOverride,

--- a/src/handlers/model-output-type.ts
+++ b/src/handlers/model-output-type.ts
@@ -1,6 +1,5 @@
 import assert from 'node:assert';
 
-import JSON5 from 'json5';
 import pupa from 'pupa';
 import type { PlainObject } from 'simplytyped';
 import {
@@ -25,6 +24,7 @@ import {
 } from '../helpers/object-settings.ts';
 import { propertyStructure } from '../helpers/property-structure.ts';
 import { isManyAndReturnOutputType } from '../helpers/type-checkers.ts';
+import { stringifyFieldOptions } from '../helpers/utils.ts';
 import { castArray } from '../helpers/utils.ts';
 import type {
   EventArguments,
@@ -322,7 +322,7 @@ function generateFieldDecorator(args: {
   // Get field overrides from config
   const fieldOverride = config.getFieldOverride(fieldInfo);
 
-  const secondArgumentOptions = JSON5.stringify({
+  const secondArgumentOptions = stringifyFieldOptions({
     ...settings?.fieldArguments(),
     defaultValue,
     description: modelField?.documentation,

--- a/src/handlers/output-type.ts
+++ b/src/handlers/output-type.ts
@@ -1,5 +1,4 @@
 import { ok } from 'assert';
-import JSON5 from 'json5';
 import { type ClassDeclarationStructure, StructureKind } from 'ts-morph';
 
 import { getEnumName } from '../helpers/get-enum-name.ts';
@@ -8,7 +7,7 @@ import { getOutputTypeName } from '../helpers/get-output-type-name.ts';
 import { getPropertyType } from '../helpers/get-property-type.ts';
 import { ImportDeclarationMap } from '../helpers/import-declaration-map.ts';
 import { propertyStructure } from '../helpers/property-structure.ts';
-import { castArray } from '../helpers/utils.ts';
+import { castArray, stringifyFieldOptions } from '../helpers/utils.ts';
 import type { EventArguments, FieldInfo, OutputType } from '../types.ts';
 
 const nestjsGraphql = '@nestjs/graphql';
@@ -167,7 +166,7 @@ export function outputType(outputType: OutputType, args: EventArguments) {
       property.decorators.push({
         arguments: [
           isList ? `() => [${graphqlType}]` : `() => ${graphqlType}`,
-          JSON5.stringify({
+          stringifyFieldOptions({
             ...settings?.fieldArguments(),
             nullable: Boolean(field.isNullable),
             ...fieldOverride,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,3 +1,4 @@
+import JSON5 from 'json5';
 import lodash from 'lodash';
 
 export const {
@@ -33,4 +34,35 @@ export function pascalCase(string: string) {
 
 export function toBoolean(value: unknown) {
   return ['true', '1', 'on'].includes(String(value));
+}
+
+/**
+ * Stringify field decorator options, handling `middleware` specially.
+ * Middleware values are emitted as identifiers (not string literals) since they
+ * are references to imported middleware functions.
+ */
+export function stringifyFieldOptions(
+  options: Record<string, unknown>,
+): string {
+  const { middleware, ...rest } = options;
+
+  // Stringify non-middleware options
+  const baseString = JSON5.stringify(rest);
+
+  // If no middleware, return the base string
+  if (!middleware) {
+    return baseString;
+  }
+
+  // Convert middleware to array of identifiers (unquoted)
+  const middlewareArray = Array.isArray(middleware) ? middleware : [middleware];
+  const middlewareString = `[${middlewareArray.join(',')}]`;
+
+  // If base is empty object, just return middleware
+  if (baseString === '{}') {
+    return `{middleware:${middlewareString}}`;
+  }
+
+  // Insert middleware into the object string (before closing brace)
+  return baseString.replace(/\}$/, `,middleware:${middlewareString}}`);
 }

--- a/src/test/field-decorator-arguments.spec.ts
+++ b/src/test/field-decorator-arguments.spec.ts
@@ -13,12 +13,12 @@ describe('fieldDecoratorArguments', () => {
         externalConfig: {
           fieldDecoratorArguments: [
             {
-              match: ({ objectName, propertyName }) =>
-                objectName.endsWith('Args') && propertyName === 'take',
               decoratorArguments: {
                 defaultValue: 10,
                 description: 'Number of records to return',
               },
+              match: ({ objectName, propertyName }) =>
+                objectName.endsWith('Args') && propertyName === 'take',
             },
           ],
         },
@@ -67,21 +67,21 @@ describe('fieldDecoratorArguments', () => {
         externalConfig: {
           fieldDecoratorArguments: [
             {
-              match: ({ objectName, propertyName }) =>
-                objectName.endsWith('Args') && propertyName === 'take',
               decoratorArguments: {
                 defaultValue: 20,
                 description: 'Limit results',
               },
+              match: ({ objectName, propertyName }) =>
+                objectName.endsWith('Args') && propertyName === 'take',
             },
             {
-              match: ({ objectName, propertyName }) =>
-                objectName.endsWith('Args') && propertyName === 'skip',
               decoratorArguments: {
-                name: 'offset',
                 defaultValue: 0,
                 description: 'Skip records',
+                name: 'offset',
               },
+              match: ({ objectName, propertyName }) =>
+                objectName.endsWith('Args') && propertyName === 'skip',
             },
           ],
         },
@@ -116,9 +116,9 @@ describe('fieldDecoratorArguments', () => {
       });
 
       expect(s.fieldDecoratorOptions).toMatchObject({
-        name: 'offset',
         defaultValue: 0,
         description: 'Skip records',
+        name: 'offset',
       });
     });
   });
@@ -129,11 +129,11 @@ describe('fieldDecoratorArguments', () => {
         externalConfig: {
           fieldDecoratorArguments: [
             {
-              match: ({ objectName, propertyName }) =>
-                objectName === 'Item' && propertyName === 'count',
               decoratorArguments: {
                 description: 'Item count override',
               },
+              match: ({ objectName, propertyName }) =>
+                objectName === 'Item' && propertyName === 'count',
             },
           ],
         },
@@ -165,21 +165,21 @@ describe('fieldDecoratorArguments', () => {
         externalConfig: {
           fieldDecoratorArguments: [
             {
-              match: ({ objectName, propertyName }) =>
-                objectName === 'User' && propertyName === 'createdAt',
               decoratorArguments: {
-                name: 'createdAt',
                 deprecationReason: 'Use timestamp instead',
                 description: 'Field creation timestamp',
+                name: 'createdAt',
               },
+              match: ({ objectName, propertyName }) =>
+                objectName === 'User' && propertyName === 'createdAt',
             },
             {
+              decoratorArguments: {
+                description: 'User identifier',
+                middleware: [],
+              },
               match: ({ objectName, propertyName }) =>
                 objectName === 'User' && propertyName === 'id',
-              decoratorArguments: {
-                middleware: [],
-                description: 'User identifier',
-              },
             },
           ],
         },
@@ -201,9 +201,9 @@ describe('fieldDecoratorArguments', () => {
       });
 
       expect(s.fieldDecoratorOptions).toMatchObject({
-        name: 'createdAt',
         deprecationReason: 'Use timestamp instead',
         description: 'Field creation timestamp',
+        name: 'createdAt',
       });
     });
 
@@ -218,6 +218,56 @@ describe('fieldDecoratorArguments', () => {
         description: 'User identifier',
         middleware: [],
       });
+    });
+  });
+
+  describe('custom middleware with customImports', () => {
+    beforeAll(async () => {
+      ({ project } = await testGenerate({
+        externalConfig: {
+          customImports: [
+            {
+              defaultImport: true,
+              from: './field-middleware',
+              name: 'loggerMiddleware',
+            },
+          ],
+          fieldDecoratorArguments: [
+            {
+              decoratorArguments: {
+                description: 'User name with logger',
+                middleware: ['loggerMiddleware'],
+              },
+              match: ({ objectName, propertyName }) =>
+                objectName === 'User' && propertyName === 'name',
+            },
+          ],
+        },
+        schema: `
+          model User {
+            id    String @id @default(cuid())
+            name  String
+          }
+        `,
+      }));
+    });
+
+    it('should have middleware on field with custom imports', () => {
+      const sourceFile = project.getSourceFileOrThrow(sf =>
+        sf.getFilePath().endsWith('user.model.ts'),
+      );
+      const userClass = sourceFile.getClass('User');
+      const nameProperty = userClass?.getProperty('name');
+      const fieldDecorator = nameProperty
+        ?.getDecorators()
+        .find(d => d.getFullName() === 'Field');
+      const decoratorText = fieldDecorator?.getText();
+
+      // Middleware should be included as identifier reference, not string literal
+      expect(decoratorText).toContain('middleware:[loggerMiddleware]');
+      // Should NOT be a string literal
+      expect(decoratorText).not.toContain("'loggerMiddleware'");
+      expect(decoratorText).toContain("description:'User name with logger'");
     });
   });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -281,8 +281,20 @@ export type FieldDecoratorArguments = {
   deprecationReason?: string;
   /** Complexity for query complexity analysis. */
   complexity?: unknown;
-  /** Array of middleware to apply to the field. */
-  middleware?: unknown[];
+  /**
+   * Middleware function name(s) to apply to the field.
+   * These are emitted as identifier references, not strings.
+   * Make sure to add corresponding customImports for the middleware.
+   *
+   * @example
+   * // Single middleware
+   * middleware: 'loggerMiddleware'
+   *
+   * @example
+   * // Multiple middleware
+   * middleware: ['loggerMiddleware', 'authMiddleware']
+   */
+  middleware?: string | string[];
   /** Mark field as nullable in GraphQL schema. */
   nullable?: boolean;
   /** Default value for the field. */


### PR DESCRIPTION
Middleware values in fieldDecoratorArguments were being serialized as quoted strings (e.g., 'loggerMiddleware') instead of identifier references (e.g., loggerMiddleware). This broke middleware usage since NestJS expects actual function references, not strings.

- Add stringifyFieldOptions helper to handle middleware specially
- Update middleware type to string | string[] with improved docs
- Add test for middleware with customImports
- Update README with middleware example

Fixes #220
Fixes #115
Fixes #137